### PR TITLE
Add option to disable hostmeta fallback when using webfinger.

### DIFF
--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -434,6 +434,9 @@ var webfinger = function(address, rel, options, callback) {
                 callback(null, jrd);
                 return;
             }
+            if (options.webfingerOnly) {
+                throw new Error("Unable to get webfinger");
+            }
             hostmeta(hostname, options, this);
         },
         function(err, hm) {


### PR DESCRIPTION
This patch adds a `webfingerOnly` option which, when set to `true`, disables hostmeta fallback.
