### PR TITLE
Expose legacy WebFinger as separate LRDD-based discovery mechanism.

### DIFF
--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -389,6 +389,73 @@ var template = function(tmpl, address, parsers, httpsOnly, callback) {
     request(((options.protocol == "https:") ? https : http), options, parsers, callback);
 };
 
+var lrdd = function(resource, options, callback) {
+    var parsed,
+        hostname;
+    
+    // Options parameter is optional
+
+    if (!callback) {
+        callback = options;
+        options = {};
+    }
+    
+    parsed = url.parse(resource);
+    hostname = parsed.hostname;
+    
+    Step(
+        function() {
+            hostmeta(hostname, options, this);
+        },
+        function(err, hm) {
+            var lrdds, json, xrd;
+            if (err) throw err;
+            if (!hm.hasOwnProperty("links")) {
+                throw new Error("No links in host-meta");
+            }
+            // First, get the lrdd ones
+            lrdds = hm.links.filter(function(link) {
+                return (link.hasOwnProperty("rel") && 
+                        link.rel == "lrdd" &&
+                        link.hasOwnProperty("template") && 
+                        (!options.httpsOnly || link.template.substr(0, 6) == "https:"));
+            });
+            if (!lrdds || lrdds.length === 0) {
+                throw new Error("No lrdd links with templates in host-meta");
+            }
+            // Try JSON ones first
+            json = lrdds.filter(function(link) {
+                return (link.hasOwnProperty("type") &&
+                        link.type == JSONTYPE);
+            });
+            if (json && json.length > 0) {
+                template(json[0].template, resource, {"application/json": jrd}, options.httpsOnly, this);
+                return;
+            }
+            // Try explicitly XRD ones second
+            xrd = lrdds.filter(function(link) {
+                return (link.hasOwnProperty("type") &&
+                        link.type == XRDTYPE);
+            });
+            if (xrd && xrd.length > 0) {
+                template(xrd[0].template, resource, {"application/xrd+xml": xrd2jrd}, options.httpsOnly, this);
+                return;
+            }
+            // Try implicitly XRD ones third
+            xrd = lrdds.filter(function(link) {
+                return (!link.hasOwnProperty("type"));
+            });
+            if (xrd && xrd.length > 0) {
+                template(xrd[0].template, resource, {"application/xrd+xml": xrd2jrd}, options.httpsOnly, this);
+                return;
+            }
+            // Otherwise, give up
+            throw new Error("No lrdd links with templates and acceptable type in host-meta");
+        },
+        callback
+    );
+}
+
 var webfinger = function(address, rel, options, callback) {
 
     var parts,
@@ -434,52 +501,7 @@ var webfinger = function(address, rel, options, callback) {
                 callback(null, jrd);
                 return;
             }
-            hostmeta(hostname, options, this);
-        },
-        function(err, hm) {
-            var lrdds, json, xrd;
-            if (err) throw err;
-            if (!hm.hasOwnProperty("links")) {
-                throw new Error("No links in host-meta");
-            }
-            // First, get the lrdd ones
-            lrdds = hm.links.filter(function(link) {
-                return (link.hasOwnProperty("rel") && 
-                        link.rel == "lrdd" &&
-                        link.hasOwnProperty("template") && 
-                        (!options.httpsOnly || link.template.substr(0, 6) == "https:"));
-            });
-            if (!lrdds || lrdds.length === 0) {
-                throw new Error("No lrdd links with templates in host-meta");
-            }
-            // Try JSON ones first
-            json = lrdds.filter(function(link) {
-                return (link.hasOwnProperty("type") &&
-                        link.type == JSONTYPE);
-            });
-            if (json && json.length > 0) {
-                template(json[0].template, address, {"application/json": jrd}, options.httpsOnly, this);
-                return;
-            }
-            // Try explicitly XRD ones second
-            xrd = lrdds.filter(function(link) {
-                return (link.hasOwnProperty("type") &&
-                        link.type == XRDTYPE);
-            });
-            if (xrd && xrd.length > 0) {
-                template(xrd[0].template, address, {"application/xrd+xml": xrd2jrd}, options.httpsOnly, this);
-                return;
-            }
-            // Try implicitly XRD ones third
-            xrd = lrdds.filter(function(link) {
-                return (!link.hasOwnProperty("type"));
-            });
-            if (xrd && xrd.length > 0) {
-                template(xrd[0].template, address, {"application/xrd+xml": xrd2jrd}, options.httpsOnly, this);
-                return;
-            }
-            // Otherwise, give up
-            throw new Error("No lrdd links with templates and acceptable type in host-meta");
+            lrdd(address, options, this);
         },
         callback
     );
@@ -495,5 +517,6 @@ var discover = function(address, callback) {
 
 exports.xrd2jrd = xrd2jrd;
 exports.webfinger = webfinger;
+exports.lrdd = lrdd;
 exports.hostmeta = hostmeta;
 exports.discover = discover;


### PR DESCRIPTION
This patch exposes the "legacy" version of WebFinger as `exports.lrdd`, and uses that when falling back.

Exposing this separately gives users of this library finer-grained control over what discovery mechanisms to utilize.
