### PR TITLE
Relax checks to allow non-acct URIs to be used with WebFinger.

### DIFF
--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -391,8 +391,7 @@ var template = function(tmpl, address, parsers, httpsOnly, callback) {
 
 var webfinger = function(address, rel, options, callback) {
 
-    var parts,
-        username,
+    var parsed,
         hostname;
 
     // Options parameter is optional
@@ -409,20 +408,8 @@ var webfinger = function(address, rel, options, callback) {
         rel = null;
     }
 
-    if (address.indexOf("@") === -1) {
-        callback(new Error(address + " doesn't look like a webfinger address"), null);
-        return;
-    }
-
-    parts = address.split("@", 2);
-
-    if (parts.length !== 2) {
-        callback(new Error(address + " doesn't look like a webfinger address"), null);
-        return;
-    }
-
-    username = parts[0];
-    hostname = parts[1];
+    parsed = url.parse(address);
+    hostname = parsed.hostname;
 
     Step(
         function() {


### PR DESCRIPTION
This patch allows non-acct: URIs to be queried using WebFinger (fixing #17).
