### PR TITLE
Improve accept header

### DIFF
--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -400,7 +400,7 @@ var httpsWebfinger = function(hostname, resource, rel, callback) {
         httpsOnly: true
     };
 
-    request(https, options, {"application/jrd+json": jrd}, callback);
+    request(https, options, {"application/jrd+json": jrd, "application/json": jrd}, callback);
 };
 
 var template = function(tmpl, address, parsers, httpsOnly, callback) {

--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -411,6 +411,7 @@ var template = function(tmpl, address, parsers, httpsOnly, callback) {
                 options = url.parse(getme);
 
             options.httpsOnly = httpsOnly;
+            options.headers = { accept: Object.keys(parsers) };
 
             request(((options.protocol == "https:") ? https : http), options, parsers, this);
         },
@@ -425,6 +426,7 @@ var template = function(tmpl, address, parsers, httpsOnly, callback) {
                 getme = tmpl.replace("{uri}", encodeURIComponent(address.substr(5))),
                 options = url.parse(getme);
                 options.httpsOnly = httpsOnly;
+                options.headers = { accept: Object.keys(parsers) };
 
                 request(((options.protocol == "https:") ? https : http), options, parsers, this);
             } else {

--- a/lib/webfinger.js
+++ b/lib/webfinger.js
@@ -400,7 +400,7 @@ var httpsWebfinger = function(hostname, resource, rel, callback) {
         httpsOnly: true
     };
 
-    request(https, options, {"application/json": jrd}, callback);
+    request(https, options, {"application/jrd+json": jrd}, callback);
 };
 
 var template = function(tmpl, address, parsers, httpsOnly, callback) {

--- a/test/webfinger-acct-uri-test.js
+++ b/test/webfinger-acct-uri-test.js
@@ -45,7 +45,7 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-acct-uri-test.js
+++ b/test/webfinger-acct-uri-test.js
@@ -45,6 +45,8 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [

--- a/test/webfinger-content-type-test.js
+++ b/test/webfinger-content-type-test.js
@@ -1,0 +1,104 @@
+// webfinger-only-test.js
+//
+// Test discovery just using Webfinger without host-meta
+//
+// Copyright 2012, E14N https://e14n.com/
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var assert = require("assert"),
+    vows = require("vows"),
+    express = require("express"),
+    https = require("https"),
+    wf = require("../lib/webfinger"),
+    fs = require("fs"),
+    path = require("path");
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+var suite = vows.describe("RFC7033 application/jrd+json content-type works");
+
+suite.addBatch({
+    "When we run an HTTPS app that just supports Webfinger": {
+        topic: function() {
+            var app = express(),
+                opts,
+                callback = this.callback;
+
+            app.get("/.well-known/webfinger", function(req, res) {
+                var uri = req.query.resource,
+                    parts = uri.split("@"),
+                    username = parts[0],
+                    hostname = parts[1];
+
+                if (username.substr(0, 5) == "acct:") {
+                    username = username.substr(5);
+                }
+
+                res.setHeader('content-type', 'application/jrd+json');
+
+                res.json({
+                    subject: uri,
+                    links: [
+                        {
+                            rel: "profile",
+                            href: "https://localhost/profile/" + username
+                        }
+                    ]
+                });
+            });
+
+            app.on("error", function(err) {
+                callback(err, null);
+            });
+
+            opts = {key: fs.readFileSync(path.join(__dirname, "data", "localhost.key")),
+                    cert: fs.readFileSync(path.join(__dirname, "data", "localhost.crt"))};
+
+            https.createServer(opts, app).listen(443, function() {
+                callback(null, app);
+            });
+        },
+        "it works": function(err, app) {
+            assert.ifError(err);
+        },
+        teardown: function(app) {
+            if (app && app.close) {
+                app.close();
+            }
+        },
+        "and we get a Webfinger": {
+            topic: function() {
+                wf.webfinger("alice@localhost", this.callback);
+            },
+            "it works": function(err, jrd) {
+                assert.ifError(err);
+                assert.isObject(jrd);
+            },
+            "it has the link": function(err, jrd) {
+                assert.ifError(err);
+                assert.isObject(jrd);
+                assert.include(jrd, "links");
+                assert.isArray(jrd.links);
+                assert.lengthOf(jrd.links, 1);
+                assert.isObject(jrd.links[0]);
+                assert.include(jrd.links[0], "rel");
+                assert.equal(jrd.links[0].rel, "profile");
+                assert.include(jrd.links[0], "href");
+                assert.equal(jrd.links[0].href, "https://localhost/profile/alice");
+            }
+        }
+    }
+});
+
+suite["export"](module);

--- a/test/webfinger-extended-test.js
+++ b/test/webfinger-extended-test.js
@@ -58,9 +58,9 @@ suite.addBatch({
                         "<Alias>http://localhost/profile/"+username+"</Alias>\n"+
                         "<Alias>http://localhost/user/1</Alias>\n"+
                         "<Link rel='profile' href='http://localhost/profile/"+username+"' />\n"+
-                        "<Link rel='http://apinamespace.org/atom' type='application/atomsvc+xml'"+
+                        "<Link rel='http://apinamespace.org/atom' type='application/atomsvc+xml' "+
                         "href='http://localhost/app/"+username+".atom'>"+
-                         "<Property type='http://apinamespace.org/atom/username'>"+username+"</Property></Link>"+
+                        "<Property type='http://apinamespace.org/atom/username'>"+username+"</Property></Link>"+
                         "</XRD>");
             });
             app.on("error", function(err) {

--- a/test/webfinger-https-no-redirect-test.js
+++ b/test/webfinger-https-no-redirect-test.js
@@ -50,7 +50,7 @@ suite.addBatch({
                     username = parts[0],
                     hostname = parts[1];
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-https-no-redirect-test.js
+++ b/test/webfinger-https-no-redirect-test.js
@@ -50,6 +50,8 @@ suite.addBatch({
                     username = parts[0],
                     hostname = parts[1];
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [

--- a/test/webfinger-only-flag-test.js
+++ b/test/webfinger-only-flag-test.js
@@ -45,7 +45,7 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-only-flag-test.js
+++ b/test/webfinger-only-flag-test.js
@@ -45,6 +45,8 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [

--- a/test/webfinger-only-lrdd-test.js
+++ b/test/webfinger-only-lrdd-test.js
@@ -45,7 +45,7 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-only-lrdd-test.js
+++ b/test/webfinger-only-lrdd-test.js
@@ -45,6 +45,8 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [

--- a/test/webfinger-only-multiple-rel-test.js
+++ b/test/webfinger-only-multiple-rel-test.js
@@ -73,7 +73,7 @@ suite.addBatch({
                     }
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json(result);
             });

--- a/test/webfinger-only-multiple-rel-test.js
+++ b/test/webfinger-only-multiple-rel-test.js
@@ -73,6 +73,8 @@ suite.addBatch({
                     }
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json(result);
             });
 

--- a/test/webfinger-only-nonacct-uri-test.js
+++ b/test/webfinger-only-nonacct-uri-test.js
@@ -38,7 +38,7 @@ suite.addBatch({
             app.get("/.well-known/webfinger", function(req, res) {
                 var uri = req.query.resource;
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-only-nonacct-uri-test.js
+++ b/test/webfinger-only-nonacct-uri-test.js
@@ -38,6 +38,8 @@ suite.addBatch({
             app.get("/.well-known/webfinger", function(req, res) {
                 var uri = req.query.resource;
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [

--- a/test/webfinger-only-test.js
+++ b/test/webfinger-only-test.js
@@ -45,7 +45,7 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-only-test.js
+++ b/test/webfinger-only-test.js
@@ -45,6 +45,8 @@ suite.addBatch({
                     username = username.substr(5);
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [

--- a/test/webfinger-only-with-rel-test.js
+++ b/test/webfinger-only-with-rel-test.js
@@ -60,7 +60,7 @@ suite.addBatch({
                                        href: "https://localhost/avatar/" + username + ".png"});
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json(result);
             });

--- a/test/webfinger-only-with-rel-test.js
+++ b/test/webfinger-only-with-rel-test.js
@@ -60,6 +60,8 @@ suite.addBatch({
                                        href: "https://localhost/avatar/" + username + ".png"});
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json(result);
             });
 

--- a/test/webfinger-server-only-takes-bare-address.js
+++ b/test/webfinger-server-only-takes-bare-address.js
@@ -46,7 +46,7 @@ suite.addBatch({
                     return;
                 }
 
-                res.setHeader('content-type', 'application/jrd+json');
+                res.setHeader('content-type', 'application/json');
 
                 res.json({
                     subject: uri,

--- a/test/webfinger-server-only-takes-bare-address.js
+++ b/test/webfinger-server-only-takes-bare-address.js
@@ -46,6 +46,8 @@ suite.addBatch({
                     return;
                 }
 
+                res.setHeader('content-type', 'application/jrd+json');
+
                 res.json({
                     subject: uri,
                     links: [


### PR DESCRIPTION
Adds accept header to requests made via the template function. 

Without the accept headers these requests would sometimes fail with an unexpected content type [error](https://github.com/e14n/webfinger/blob/master/lib/webfinger.js#L224). This happens when a server provides an lrdd from host-meta, which specifies a `type` that differs from the default response type of the given URL. 

Also, changes the expected webfinger response content-type from application/json  to application/jrd+json